### PR TITLE
Use the output directly

### DIFF
--- a/Bicep/AzureBicepHealthFhirServer.cs
+++ b/Bicep/AzureBicepHealthFhirServer.cs
@@ -10,10 +10,8 @@ public static class AzureBicepHealthFhirServer
 {
     public static IResourceBuilder<AzureBicepResource> AddHealthDataFhirServer(this IDistributedApplicationBuilder builder, string name, IResourceBuilder<AzureStorageResource> storage)
     {
-        var storageAccountName = ReferenceExpression.Create($"{storage.GetOutput("name")}");
-
         return builder.AddBicepTemplate(name, "Bicep/azurehealthfhirserver.bicep")
-            .WithParameter("storageAccountName", () => storageAccountName)
+            .WithParameter("storageAccountName", storage.GetOutput("name"))
             .WithParameter("name", name);
     }
 }


### PR DESCRIPTION
No need to use callbacks or reference expressions. Also filed https://github.com/dotnet/aspire/issues/9385 so we expose strongly typed name properties from our azure resources to make these scenarios a bit easier.